### PR TITLE
Add script to compare column values across data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ python compare.py file1.csv file2.jsonl --column Id --output result.csv
 The script reads the primary file (first argument) and adds a `status` column with
 either `FOUND` or `NOT FOUND` depending on whether the value from the specified
 column exists in the secondary file.
+
+To limit the result file to only rows with a particular status, use the
+`--filter` option:
+
+```
+python compare.py file1.csv file2.jsonl --column Id --output result.csv --filter FOUND
+```
+
+Valid filters are `FOUND` and `NOT_FOUND`.


### PR DESCRIPTION
## Summary
- add `compare.py` to check if a column value appears in two CSV/JSONL files and mark rows as FOUND/NOT FOUND
- document new comparison utility in README

## Testing
- `python -m py_compile compare.py`
- `python compare.py file1.csv file2.jsonl --column Id --output result.csv`

------
https://chatgpt.com/codex/tasks/task_e_68bf2f332d68832da2e07d80059225b0