### PR TITLE
Add CLI parameters for query and output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This tool connects to Salesforce using the Bulk API 2.0, runs a SOQL query, and 
 
 ## How to run
 
-1. Create a `.env` file with your credentials (see `.env.example`)
+1. Create a `.env` file with your Salesforce credentials (see `.env.example`).
 2. Install dependencies:
    ```
    pip install -r requirements.txt
    ```
 3. Run:
    ```
-   python main.py [--format jsonl|csv]
+   python main.py --query "SELECT Id FROM Account" [--format jsonl|csv] [--directory output]
    ```
 
 ## Comparing Exported Files

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import argparse
 from sfdc_export.auth import authenticate
 from sfdc_export.job import create_job, wait_for_completion
 from sfdc_export.extractor import extract_results
+from sfdc_export.logger import set_log_directory
 
 
 def parse_args():
@@ -13,14 +14,31 @@ def parse_args():
         default="jsonl",
         help="Output format (jsonl or csv)",
     )
+    parser.add_argument(
+        "--query",
+        required=True,
+        help="SOQL query to execute",
+    )
+    parser.add_argument(
+        "--directory",
+        default="./output",
+        help="Directory to save exported files",
+    )
     return parser.parse_args()
 
 def main():
     args = parse_args()
+    set_log_directory(args.directory)
     token, instance_url = authenticate()
-    job_id = create_job(token, instance_url)
+    job_id = create_job(token, instance_url, args.query)
     wait_for_completion(token, instance_url, job_id)
-    extract_results(token, instance_url, job_id, output_format=args.format)
+    extract_results(
+        token,
+        instance_url,
+        job_id,
+        output_format=args.format,
+        output_dir=args.directory,
+    )
 
 if __name__ == "__main__":
     main()

--- a/sfdc_export/config.py
+++ b/sfdc_export/config.py
@@ -9,5 +9,4 @@ SFDC_CLIENT_ID = os.getenv("SFDC_CLIENT_ID")
 SFDC_CLIENT_SECRET = os.getenv("SFDC_CLIENT_SECRET")
 SFDC_USERNAME = os.getenv("SFDC_USERNAME")
 SFDC_PASSWORD = os.getenv("SFDC_PASSWORD")
-SFDC_QUERY = os.getenv("SFDC_QUERY")
-SFDC_DIRECTORY = os.getenv("SFDC_DIRECTORYFILES", "./output")
+# Query and output directory are now provided via command-line arguments

--- a/sfdc_export/extractor.py
+++ b/sfdc_export/extractor.py
@@ -8,14 +8,20 @@ from sfdc_export import config
 from sfdc_export.logger import log
 
 
-def extract_results(token: str, instance_url: str, job_id: str, output_format: str = "jsonl"):
+def extract_results(
+    token: str,
+    instance_url: str,
+    job_id: str,
+    output_format: str = "jsonl",
+    output_dir: str = "./output",
+):
     headers = {"Authorization": f"Bearer {token}"}
     locator = None
     chunk = 0
     total = 0
     extension = "csv" if output_format == "csv" else "jsonl"
-    output_file = os.path.join(config.SFDC_DIRECTORY, f"result.{extension}")
-    os.makedirs(config.SFDC_DIRECTORY, exist_ok=True)
+    output_file = os.path.join(output_dir, f"result.{extension}")
+    os.makedirs(output_dir, exist_ok=True)
 
     file_kwargs = {"newline": ""} if output_format == "csv" else {}
 

--- a/sfdc_export/job.py
+++ b/sfdc_export/job.py
@@ -3,7 +3,7 @@ import time
 from sfdc_export import config
 from sfdc_export.logger import log
 
-def create_job(token: str, instance_url: str) -> str:
+def create_job(token: str, instance_url: str, query: str) -> str:
     log("🚀 Creating query job...")
     headers = {
         "Authorization": f"Bearer {token}",
@@ -12,7 +12,7 @@ def create_job(token: str, instance_url: str) -> str:
     response = requests.post(
         f"{instance_url}/services/data/{config.SFDC_MYAPI}/jobs/query",
         headers=headers,
-        json={"operation": "query", "query": config.SFDC_QUERY}
+        json={"operation": "query", "query": query}
     )
 
     if response.status_code != 200:

--- a/sfdc_export/logger.py
+++ b/sfdc_export/logger.py
@@ -1,10 +1,18 @@
 import os
 from datetime import datetime
-from sfdc_export import config
+
+LOG_DIRECTORY = "./output"
+
+
+def set_log_directory(path: str):
+    """Configure where log files are written."""
+    global LOG_DIRECTORY
+    LOG_DIRECTORY = path
+
 
 def log(message: str):
-    os.makedirs(config.SFDC_DIRECTORY, exist_ok=True)
-    log_file = os.path.join(config.SFDC_DIRECTORY, "bulk_extraction.log")
+    os.makedirs(LOG_DIRECTORY, exist_ok=True)
+    log_file = os.path.join(LOG_DIRECTORY, "bulk_extraction.log")
     timestamp = datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
     entry = f"{timestamp} {message}"
     print(entry)


### PR DESCRIPTION
## Summary
- Allow specifying SOQL query and output directory via CLI options
- Refactor logging and extraction modules to use provided output directory
- Document new CLI usage in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf3606b6bc832da23c020105edb76e