### PR TITLE
Add client credentials authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ This tool connects to Salesforce using the Bulk API 2.0, runs a SOQL query, and 
    python main.py --query "SELECT Id FROM Account" [--format jsonl|csv] [--directory output]
    ```
 
+## Authentication configuration
+
+The application supports the Salesforce OAuth password grant (default) and the
+client credentials flow. Configure the `.env` file with the following
+variables:
+
+- `SFDC_MYORG`: OAuth token endpoint (for example,
+  `https://login.salesforce.com/services/oauth2/token`).
+- `SFDC_MYAPI`: Bulk API version path (for example, `v59.0`).
+- `SFDC_CLIENT_ID` and `SFDC_CLIENT_SECRET`: Connected app credentials.
+- `SFDC_GRANT_TYPE`: Optional. Use `password` (default) or
+  `client_credentials`.
+- `SFDC_USERNAME` and `SFDC_PASSWORD`: Required only when `SFDC_GRANT_TYPE` is
+  `password`.
+- `SFDC_CLIENT_AUDIENCE`: Required only when `SFDC_GRANT_TYPE` is
+  `client_credentials`.
+
 ## Comparing Exported Files
 
 Use `compare.py` to check if a given column value appears in two CSV or JSONL files.

--- a/sfdc_export/auth.py
+++ b/sfdc_export/auth.py
@@ -1,20 +1,52 @@
 import requests
+
 from sfdc_export import config
 from sfdc_export.logger import log
 
-def authenticate():
-    log("🔐 Authenticating with Salesforce...")
-    response = requests.post(config.SFDC_MYORG, data={
-        "grant_type": "password",
+
+def _build_auth_payload() -> dict:
+    """Create the payload for the authentication request."""
+    grant_type = (config.SFDC_GRANT_TYPE or "password").strip().lower()
+    payload = {
+        "grant_type": grant_type,
         "client_id": config.SFDC_CLIENT_ID,
         "client_secret": config.SFDC_CLIENT_SECRET,
-        "username": config.SFDC_USERNAME,
-        "password": config.SFDC_PASSWORD
-    })
+    }
+
+    if grant_type == "password":
+        if not (config.SFDC_USERNAME and config.SFDC_PASSWORD):
+            log("❌ SFDC_USERNAME and SFDC_PASSWORD are required for password grant type.")
+            raise SystemExit()
+        payload.update(
+            {
+                "username": config.SFDC_USERNAME,
+                "password": config.SFDC_PASSWORD,
+            }
+        )
+    elif grant_type == "client_credentials":
+        if not config.SFDC_CLIENT_AUDIENCE:
+            log("❌ SFDC_CLIENT_AUDIENCE is required for client_credentials grant type.")
+            raise SystemExit()
+        payload["audience"] = config.SFDC_CLIENT_AUDIENCE
+    else:
+        log(f"❌ Unsupported SFDC_GRANT_TYPE: {config.SFDC_GRANT_TYPE}")
+        raise SystemExit()
+
+    return payload
+
+
+def authenticate():
+    log("🔐 Authenticating with Salesforce...")
+    payload = _build_auth_payload()
+    response = requests.post(config.SFDC_MYORG, data=payload)
 
     if response.status_code != 200:
         log(f"❌ Authentication error: {response.text}")
         raise SystemExit()
 
     data = response.json()
-    return data["access_token"], data["instance_url"]
+    try:
+        return data["access_token"], data["instance_url"]
+    except KeyError:
+        log(f"❌ Unexpected authentication response: {data}")
+        raise SystemExit()

--- a/sfdc_export/config.py
+++ b/sfdc_export/config.py
@@ -9,4 +9,6 @@ SFDC_CLIENT_ID = os.getenv("SFDC_CLIENT_ID")
 SFDC_CLIENT_SECRET = os.getenv("SFDC_CLIENT_SECRET")
 SFDC_USERNAME = os.getenv("SFDC_USERNAME")
 SFDC_PASSWORD = os.getenv("SFDC_PASSWORD")
+SFDC_GRANT_TYPE = os.getenv("SFDC_GRANT_TYPE", "password")
+SFDC_CLIENT_AUDIENCE = os.getenv("SFDC_CLIENT_AUDIENCE")
 # Query and output directory are now provided via command-line arguments


### PR DESCRIPTION
## Summary
- allow switching between Salesforce password and client credentials grants via configuration
- validate required credentials for each grant type during authentication
- document environment variables for configuring authentication

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc6039fbb0832d86d5674f96ca6df5